### PR TITLE
fix autoscroll when tab gets refocused

### DIFF
--- a/app/src/Chat.svelte
+++ b/app/src/Chat.svelte
@@ -46,6 +46,14 @@
         consumeChatRequest = apiClient.consumeChat(50, handleChatUpdated, (code, msg) => {
             setTimeout(consumeChat, 5000);
         });
+        document.addEventListener("visibilitychange", function() {
+            if(!document.hidden) {
+                chatContainer.scrollTo({
+                    top: chatContainer.scrollHeight,
+                    behavior: "smooth",
+                });
+            }
+        })
     }
     onDestroy(() => {
         if (consumeChatRequest !== undefined) {


### PR DESCRIPTION
"When a tab is not visible (tab can be active but not visible), chrome doesn't do the UI calculations. Because of that, scrolling calculations are not done, only visible measurement can be done." as stated [here](https://stackoverflow.com/a/52836893). So you can use the `visibilitychange` listener for the document and have it scroll to the bottom of the chat whenever the tab is refocused.